### PR TITLE
REFACTOR : 면접 대상자 관리 탭에서 서류 합격 취소 기능 제거

### DIFF
--- a/src/components/board/Board.jsx
+++ b/src/components/board/Board.jsx
@@ -54,7 +54,7 @@ const Board = ({ pass, type, onAdd, onDelete }) => {
 
   const tracks = [
     { value: "all", label: "전체트랙" },
-    { value: "pm", label: "기획 · 디자인" },
+    { value: "pm", label: "기획·디자인" },
     { value: "fe", label: "프론트엔드" },
     { value: "be", label: "백엔드" },
   ];

--- a/src/components/board/Board.jsx
+++ b/src/components/board/Board.jsx
@@ -221,9 +221,9 @@ const Board = ({ pass, type, onAdd, onDelete }) => {
             <B.Button color="#8fe088" onClick={handleAddButtonClick}>
               <B.ButtonText>최종 합격자로 추가 +</B.ButtonText>
             </B.Button>
-            <B.Button color="#e08888" onClick={handleDeleteButtonClick}>
+            {/* <B.Button color="#e08888" onClick={handleDeleteButtonClick}>
               <B.ButtonText> 서류 합격 취소</B.ButtonText>
-            </B.Button>
+            </B.Button> */}
           </B.ButtonSet>
         </B.ButtonContainer>
       )}

--- a/src/components/board/style/Board.style.jsx
+++ b/src/components/board/style/Board.style.jsx
@@ -22,6 +22,7 @@ export const customStyles = {
     borderColor: "white",
     borderRadius: "10px",
     boxShadow: "none",
+    cursor: "pointer",
     "&:hover": {
       borderColor: "white",
     },
@@ -33,6 +34,8 @@ export const customStyles = {
     fontWeight: state.isSelected ? "bold" : "normal",
     color: "black",
     backgroundColor: "white",
+    whiteSpace: "nowrap",
+    cursor: "pointer",
     "&:hover": {
       backgroundColor: "#d2d2d2",
     },

--- a/src/pages/recruit/InterviewTimePage.jsx
+++ b/src/pages/recruit/InterviewTimePage.jsx
@@ -46,7 +46,7 @@ const InterviewTimePage = () => {
           <S.About>
             면접 대상자의 면접 시간을 조정하고, 최종 합격을 확정합니다.
           </S.About>
-          <S.SubTitle>서류 합격자 테이블</S.SubTitle>
+          <S.SubTitle>면접 대상자 테이블</S.SubTitle>
           <Board
             pass={docs}
             type="type3"


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #25 

## ✨ 내용
- 면접 대상자 관리 페이지에서 서류 합격 취소 버튼 제거
- 면접 단계에서 사용되는 문구 및 테이블 타이틀 정리
- 필터 및 선택 컴포넌트 스타일 개선


## 📸 스크린샷(선택)
<img width="1424" height="812" alt="스크린샷 2026-02-04 오후 11 30 28" src="https://github.com/user-attachments/assets/b968d512-2d91-430e-8c08-a1b24912ae4c" />
